### PR TITLE
defers loading of mac address on first usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,16 +55,18 @@ function parseMacAddress(address) {
 var macAddress = randomHost;
 var macAddressLoaded = false;
 
-require('macaddress').one(function (err, result) {
-    if (!err) {
-        macAddress = parseMacAddress(result);
-    }
-    macAddressLoaded = true;
-});
+function loadMacAddress() {
+  require('macaddress').one(function (err, result) {
+      if (!err) {
+          macAddress = parseMacAddress(result);
+      }
+      macAddressLoaded = true;
+  });
+};
 
 // UUID class
 var UUID = function (uuid) {
-    
+
     var check = UUID.check(uuid);
     if (!check) {
         throw "not a UUID";
@@ -104,7 +106,7 @@ function error(message, callback) {
 
 // read stringified uuid into a Buffer
 function parse(string) {
-    
+
     var buffer = new Buffer(16);
     var j = 0;
     for (var i = 0; i < 16; i++) {
@@ -377,7 +379,7 @@ function uuidRandomFast() {
     var r3 = Math.random() * 0x100000000;
     var r4 = Math.random() * 0x100000000;
 
-    return byte2hex[ r1        & 0xff] + 
+    return byte2hex[ r1        & 0xff] +
            byte2hex[ r1 >>>  8 & 0xff] +
            byte2hex[ r1 >>> 16 & 0xff] +
            byte2hex[ r1 >>> 24 & 0xff] + '-' +
@@ -431,6 +433,9 @@ UUID.v1 = function v1(arg1, arg2) {
     var nodeId = options.mac;
 
     if (nodeId === undefined) {
+        if(!macAddressLoaded) {
+            loadMacAddress();
+        }
         if (!macAddressLoaded && callback) {
             setImmediate(function () {
                 UUID.v1(options, callback);


### PR DESCRIPTION
Apparently, node 4.2.something on OSv (which is a unikernel image) cannot list network interfaces via `require('os').networkInterfaces()`. This made it obvious the mac address is loaded even if it is unused: Though I only use `v4fast()`, initialization of `v1()` broke my usage, though only when running inside the OSv image. I'll dig in the latter issue separately.

To circumvent this, I made the attached quick-fix do defer the retrieval of the mac address until it is needed. I hope you consider this useful.
